### PR TITLE
Fix widget resolution

### DIFF
--- a/main.py
+++ b/main.py
@@ -42,7 +42,6 @@ class NotificationPanel(qtw.QWidget):
         self.setFixedSize(QSize(math.floor(panelWidth), math.floor(panelHeight)))
         
         # Position
-
         x = availableScreenDim.width() - self.width()
         y = 2 * availableScreenDim.height() - screenDim.height() - self.height()
         self.move(x,y)

--- a/main.py
+++ b/main.py
@@ -28,26 +28,25 @@ class NotificationPanel(qtw.QWidget):
         self.setWindowTitle('Stopwatch Notify')
         self.setWindowIcon(qtg.QIcon(icon_path))
 
-        # Size
-        # self.setFixedSize(400, 100)
-        
-        # Position
+        # Get screen geometry
         screenDim = qtw.QDesktopWidget().screenGeometry()
         availableScreenDim = qtw.QDesktopWidget().availableGeometry()
+
+        # Size
+        
+        # Set the width to 20% of the screen width
+        panelWidth = availableScreenDim.width() * 0.20
+
+        # Set the height to 25% of the panel width
+        panelHeight = panelWidth * 0.25
+        self.setFixedSize(QSize(math.floor(panelWidth), math.floor(panelHeight)))
+        
+        # Position
+
         x = availableScreenDim.width() - self.width()
         y = 2 * availableScreenDim.height() - screenDim.height() - self.height()
-
-        panelWidth = availableScreenDim.width() * 0.4  # Set the width to 40% of the screen width
-
-        panelHeight = panelWidth * 0.25  # Set the height to 25% of the panel width
-
-        self.setFixedSize(QSize(math.floor(panelWidth),math.floor(panelHeight)))
-
-
         self.move(x,y)
 
-        
-        
         # Setup
         self.windowLayout = qtw.QVBoxLayout()
         self.windowLayout.setSpacing(0)

--- a/main.py
+++ b/main.py
@@ -8,7 +8,8 @@ from random import choice as randChoice
 
 from playsound import playsound
 
-from PyQt5.QtCore import QPoint, QTimer, Qt
+import math
+from PyQt5.QtCore import QPoint, QTimer, Qt, QSize
 import PyQt5.QtGui as qtg
 import PyQt5.QtWidgets as qtw
 
@@ -28,7 +29,7 @@ class NotificationPanel(qtw.QWidget):
         self.setWindowIcon(qtg.QIcon(icon_path))
 
         # Size
-        self.setFixedSize(400, 100)
+        # self.setFixedSize(400, 100)
         
         # Position
         screenDim = qtw.QDesktopWidget().screenGeometry()
@@ -36,8 +37,17 @@ class NotificationPanel(qtw.QWidget):
         x = availableScreenDim.width() - self.width()
         y = 2 * availableScreenDim.height() - screenDim.height() - self.height()
 
+        panelWidth = availableScreenDim.width() * 0.4  # Set the width to 40% of the screen width
+
+        panelHeight = panelWidth * 0.25  # Set the height to 25% of the panel width
+
+        self.resize(QSize(math.floor(panelWidth),math.floor(panelHeight)))
+
+
         self.move(x,y)
 
+        
+        
         # Setup
         self.windowLayout = qtw.QVBoxLayout()
         self.windowLayout.setSpacing(0)

--- a/main.py
+++ b/main.py
@@ -41,7 +41,7 @@ class NotificationPanel(qtw.QWidget):
 
         panelHeight = panelWidth * 0.25  # Set the height to 25% of the panel width
 
-        self.resize(QSize(math.floor(panelWidth),math.floor(panelHeight)))
+        self.setFixedSize(QSize(math.floor(panelWidth),math.floor(panelHeight)))
 
 
         self.move(x,y)


### PR DESCRIPTION
Adjust the self.setFixedSize parameters to scale with the user's screen resolution.
Uses PyQt5's QDesktopWidget().screenGeometry() and QDesktopWidget().availableGeometry() methods to scale user resolution.

This is regarding issue no. #30.